### PR TITLE
Override cellSize dimensions with cellStyle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,6 @@ class SmoothPinCodeInput extends Component {
               return (
                 <Animatable.View key={idx}
                   style={[
-                    cellStyle,
                     cellFocused ? cellStyleFocused : {},
                     {
                       width: cellSize,
@@ -134,7 +133,8 @@ class SmoothPinCodeInput extends Component {
                       flexDirection: 'row',
                       alignItems: 'center',
                       justifyContent: 'center',
-                    }
+                    },
+                    cellStyle
                   ]}
                   animation={ idx === value.length && focused ? animationFocused : null }
                   iterationCount="infinite"

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,6 @@ class SmoothPinCodeInput extends Component {
               return (
                 <Animatable.View key={idx}
                   style={[
-                    cellFocused ? cellStyleFocused : {},
                     {
                       width: cellSize,
                       height: cellSize,
@@ -134,7 +133,8 @@ class SmoothPinCodeInput extends Component {
                       alignItems: 'center',
                       justifyContent: 'center',
                     },
-                    cellStyle
+                    cellStyle,
+                    cellFocused ? cellStyleFocused : {},
                   ]}
                   animation={ idx === value.length && focused ? animationFocused : null }
                   iterationCount="infinite"


### PR DESCRIPTION
If don't want the shape of a cell to be square you can now override the width and height via the cellStyle property.