### PR TITLE
fix(textinput): no need pass props to TextInput

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,6 @@ class SmoothPinCodeInput extends Component {
           }
         </View>
         <TextInput
-          {...this.props}
           value={value}
           ref={this.inputRef}
           onChangeText={this._inputCode}


### PR DESCRIPTION
hi @xamous thanks your great work,
and i found that when i use it in `react-native-web` , there is tons of red warning.
finally i found that you pass the component's props to the TextInput, 
and you can check what is the valid props about TextInput: https://facebook.github.io/react-native/docs/textinput

so, i think you can delete this line, and everything still working.

https://github.com/xamous/react-native-smooth-pincode-input/blob/53e2d92782aa7f8410d168d131c991f96be22dbc/src/index.js#L161