### PR TITLE
make cell left to right in rtl mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   Text,
   TextInput,
   StyleSheet,
+  I18nManager,
   ViewPropTypes,
 } from 'react-native';
 import * as Animatable from 'react-native-animatable';
@@ -112,7 +113,7 @@ class SmoothPinCodeInput extends Component {
         ]}>
         <View style={{
           position: 'absolute', margin: 0, height: '100%',
-          flexDirection: 'row',
+          flexDirection: I18nManager.isRTL ? 'row-reverse': 'row',
           alignItems: 'center',
         }}>
           {


### PR DESCRIPTION
In RTL language the cells are reversed in android. this will reverse the order for RTL.
mathematics and numbers in RTL languages is the same as LTR. 

not tested in iOS.

thanks for this great library.