### PR TITLE
add testID from props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,7 @@ class SmoothPinCodeInput extends Component {
       textStyleFocused,
       keyboardType,
       animationFocused,
+      testID,
     } = this.props;
     const { maskDelay, focused } = this.state;
     return (
@@ -181,7 +182,8 @@ class SmoothPinCodeInput extends Component {
             flex: 1,
             opacity: 0,
             textAlign: 'center',
-          }} />
+          }}
+          testID={testID || undefined} />
       </Animatable.View>
     );
   }


### PR DESCRIPTION
https://github.com/xamous/react-native-smooth-pincode-input/commit/43614fa9359a6559a5010f68510c01e920464feb

commit above breaks testID from props too component.
PR includes testID from props.