### PR TITLE
Allow to pass down input props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,7 @@ class SmoothPinCodeInput extends Component {
       keyboardType,
       animationFocused,
       testID,
+      inputProps,
     } = this.props;
     const { maskDelay, focused } = this.state;
     return (
@@ -183,7 +184,8 @@ class SmoothPinCodeInput extends Component {
             opacity: 0,
             textAlign: 'center',
           }}
-          testID={testID || undefined} />
+          testID={testID || undefined}
+          {...inputProps} />
       </Animatable.View>
     );
   }
@@ -205,6 +207,7 @@ class SmoothPinCodeInput extends Component {
     textStyle: styles.textStyleDefault,
     textStyleFocused: styles.textStyleFocusedDefault,
     animationFocused: 'pulse',
+    inputProps: {},
   };
 }
 
@@ -240,6 +243,8 @@ SmoothPinCodeInput.propTypes = {
   onBackspace: PropTypes.func,
 
   keyboardType: PropTypes.string,
+
+  inputProps: PropTypes.exact(TextInput.propTypes),
 };
 
 export default SmoothPinCodeInput;


### PR DESCRIPTION
Adds "inputProps" so it is possible to pass down custom props to the react TextInput.

For example:
```js
<SmoothPinCodeInput
  inputProps={{
    onSubmitEditing: () => console.log('submit'),
  }}
/>
```