### PR TITLE
Disable fullscreen keyboard when in landscape on Android by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,7 @@ class SmoothPinCodeInput extends Component {
       testID,
       editable,
       inputProps,
+      disableFullscreenUI,
     } = this.props;
     const { maskDelay, focused } = this.state;
     return (
@@ -186,7 +187,7 @@ class SmoothPinCodeInput extends Component {
           }
         </View>
         <TextInput
-          disableFullscreenUI={true}
+          disableFullscreenUI={disableFullscreenUI}
           value={value}
           ref={this.inputRef}
           onChangeText={this._inputCode}
@@ -235,6 +236,7 @@ class SmoothPinCodeInput extends Component {
     animationFocused: 'pulse',
     editable: true,
     inputProps: {},
+    disableFullscreenUI: true,
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -186,6 +186,7 @@ class SmoothPinCodeInput extends Component {
           }
         </View>
         <TextInput
+          disableFullscreenUI={true}
           value={value}
           ref={this.inputRef}
           onChangeText={this._inputCode}


### PR DESCRIPTION
By default, when in landscape on an android device many handsets offer the fullscreen numeric keyboard:
![Screenshot_20190831-131018](https://user-images.githubusercontent.com/422196/64063790-0d2b2900-cbf1-11e9-9f5a-786b79b2edda.png)
Obviously this is not particularly helpful when trying to get a user to input a code that is being displayed.

This PR defaults it to not use the fullscreen keyboard UI but still offers it as an option via props.

![image](https://user-images.githubusercontent.com/422196/64063809-44013f00-cbf1-11e9-9fea-79d17f90a5fb.png)

(Please excuse the latter screenshot, I had to remove the app UI from the top half as it's pre-release. The important thing is that the keyboard is starting half way down the screen instead of covering it)