### PR TITLE
onFulfill triggered before state update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,9 @@ class SmoothPinCodeInput extends Component {
       onTextChange(code);
     }
     if (code.length === codeLength && onFulfill) {
-      onFulfill(code);
+      //Wait for last character state update before submit
+      setTimeout(() => onFulfill(code), 50 );
+      
     }
 
     // handle password mask


### PR DESCRIPTION
A quick fix for issue #27. Wait for the last character before calling onFulfill. 