### PR TITLE
Fixes ViewPropTypes will be removed from React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-smooth-pincode-input",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "A cross-platform, smooth, lightweight, customizable PIN code input component for React Native.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,10 @@ import {
   TextInput,
   StyleSheet,
   I18nManager,
-  ViewPropTypes,
 } from 'react-native';
+
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
+
 import * as Animatable from 'react-native-animatable';
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Fixes ViewPropTypes will be removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types' warning