### PR TITLE
making the pincode input more stylable with passing a new style prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import * as Animatable from 'react-native-animatable';
 
 const styles = StyleSheet.create({
   containerDefault: {},
+  cellsContainerDefault: {},
   cellDefault: {
     borderColor: 'gray',
     borderWidth: 1,
@@ -124,6 +125,7 @@ class SmoothPinCodeInput extends Component {
       mask,
       autoFocus,
       containerStyle,
+      cellsContainerStyle,
       cellStyle,
       cellStyleFocused,
       cellStyleFilled,
@@ -253,6 +255,7 @@ class SmoothPinCodeInput extends Component {
     autoFocus: false,
     restrictToNumbers: false,
     containerStyle: styles.containerDefault,
+    cellsContainerStyle: styles.cellsContainerDefault,
     cellStyle: styles.cellDefault,
     cellStyleFocused: styles.cellFocusedDefault,
     textStyle: styles.textStyleDefault,

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,7 @@ class SmoothPinCodeInput extends Component {
           flexDirection: I18nManager.isRTL ? 'row-reverse': 'row',
           alignItems: 'center',
         },
-         cellsContainerDefault,          
+         cellsContainerStyle,          
        ]}>
           {
             Array.apply(null, Array(codeLength)).map((_, idx) => {

--- a/src/index.js
+++ b/src/index.js
@@ -150,11 +150,13 @@ class SmoothPinCodeInput extends Component {
         },
           containerStyle,
         ]}>
-        <View style={{
+        <View style={[{
           position: 'absolute', margin: 0, height: '100%',
           flexDirection: I18nManager.isRTL ? 'row-reverse': 'row',
           alignItems: 'center',
-        }}>
+        },
+         cellsContainerDefault,          
+       ]}>
           {
             Array.apply(null, Array(codeLength)).map((_, idx) => {
               const cellFocused = focused && idx === value.length;


### PR DESCRIPTION
With this change, I can make the 4 inputs take up the entire available space and use justify-content: 'space-between' to make space between them.