### PR TITLE
fix(onFulfill): make sure to fire once per code fulfill

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ class SmoothPinCodeInput extends Component {
   };
   ref = React.createRef();
   inputRef = React.createRef();
-
+  didFireOnfulfillForCodeRef = React.createRef();
+  
   animate = ({ animation = "shake", duration = 650 }) => {
     if (!this.props.animated) {
       return new Promise((resolve, reject) => reject(new Error("Animations are disabled")));
@@ -66,10 +67,16 @@ class SmoothPinCodeInput extends Component {
       code = (code.match(/[0-9]/g) || []).join("");
     }
 
+    if (code.length < codeLength) {
+      this.didFireOnfulfillForCodeRef.current = false
+    }
+
     if (onTextChange) {
       onTextChange(code);
     }
-    if (code.length === codeLength && onFulfill) {
+    
+    if (code.length === codeLength && !this.didFireOnfulfillForCodeRef.current && onFulfill) {
+      this.didFireOnfulfillForCodeRef.current = true
       onFulfill(code);
     }
 


### PR DESCRIPTION
onFulfill always fired twice before which caused bugs if implementations rely on code fulfill event detection i.e to post requests automatically. Ths fix will make sure to only fire 1 event per code completion